### PR TITLE
Unescape string literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,7 @@ dependencies = [
  "serde_json",
  "sha256",
  "thiserror",
+ "unescape",
  "url",
  "uuid",
 ]
@@ -1257,6 +1258,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unescape"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde = "1"
 serde_json = "1"
 sha256 = "1"
 thiserror = "2"
+unescape = "0.1"
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,6 +385,7 @@ mod tests {
   #[case("1.0", (1.0).into())]
   #[case("6.02e+5", (6.02e+5).into())]
   #[case("\"\"", Value::String("".into()))]
+  #[case("\" \"", Value::String(" ".into()))]
   #[case("\"foobar\"", Value::String("foobar".into()))]
   #[case("\"\\\\foobar\"", Value::String("\\foobar".into()))]
   #[case("\"\\u2705\"", Value::String("✅".into()))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,6 +380,25 @@ mod tests {
   }
 
   #[rstest]
+  #[case("1", (1).into())]
+  #[case("-1", (-1).into())]
+  #[case("1.0", (1.0).into())]
+  #[case("6.02e+5", (6.02e+5).into())]
+  #[case("\"\"", Value::String("".into()))]
+  #[case("\"foobar\"", Value::String("foobar".into()))]
+  #[case("\"\\\\foobar\"", Value::String("\\foobar".into()))]
+  #[case("\"\\u2705\"", Value::String("✅".into()))]
+  fn parse_literals(#[case] query: &str, #[case] expected: Value) -> Result<()> {
+    let jslt: Jslt = query.parse()?;
+
+    let output = jslt.transform_value(&Value::Null)?;
+
+    assert_eq!(output, expected);
+
+    Ok(())
+  }
+
+  #[rstest]
   #[case("null", "[1, 2, 3]", "false")]
   #[case("1", "[1, 2, 3]", "true")]
   #[case("0", "[1, 2, 3]", "false")]

--- a/src/transform/value.rs
+++ b/src/transform/value.rs
@@ -153,7 +153,9 @@ impl FromPairs for StringTransformer {
     let rule = inner.as_rule();
 
     if matches!(rule, Rule::Inner) {
-      Ok(StringTransformer(inner.as_str().to_owned()))
+      Ok(StringTransformer(
+        unescape::unescape(inner.as_str()).unwrap_or_default(),
+      ))
     } else {
       Err(JsltError::UnexpectedInput(
         Rule::String,


### PR DESCRIPTION
Add correct unescaping for string literals when defined in query (fixes #19)