### PR TITLE
Update so split function will not return "ends" when passing empty pattern

### DIFF
--- a/src/context/builtins.rs
+++ b/src/context/builtins.rs
@@ -409,6 +409,16 @@ pub fn capture(input: &Value, re: &Value) -> Result<Value> {
 pub fn split(value: &Value, re: &Value) -> Result<Value> {
   match (value, re) {
     (Value::Null, _) => Ok(Value::Null),
+
+    (Value::String(value), Value::String(empty)) if empty.is_empty() => Ok(Value::Array(
+      value
+        .split("")
+        .skip(1) // custom case where the patten is empty to match java behaviour
+        .take(value.len())
+        .map(str::to_owned)
+        .map(Value::String)
+        .collect(),
+    )),
     (Value::String(value), Value::String(re)) => {
       let re = Regex::new(re).map_err(|err| {
         JsltError::RuntimeError(format!("Unexpected error when parsing re: {err}"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,7 +779,7 @@ mod tests {
   #[case("1,2,3,4,5".into(), ";".into(), r#"["1,2,3,4,5"]"#)]
   #[case("null", ";".into(), "null")]
   #[case(",2".into(), ",".into(), r#"["", "2"]"#)]
-  // #[case("2,".into(), ",".into(), r#"["2"]"#)] TODO: maybe add the logic
+  #[case("22".into(), "".into(), r#"["2", "2"]"#)]
   fn function_split(
     #[case] left: Value,
     #[case] right: Value,


### PR DESCRIPTION
fixes #25